### PR TITLE
Add test for lazy keyword argument

### DIFF
--- a/spec/bridgetown-media-transformation_spec.rb
+++ b/spec/bridgetown-media-transformation_spec.rb
@@ -22,7 +22,6 @@ describe(BridgetownMediaTransformation) do
     }
   end
   let(:site) { Bridgetown::Site.new(config) }
-  let(:contents) { File.read(dest_dir("index.html")) }
   before(:each) do
     metadata = metadata_defaults.merge(metadata_overrides).to_yaml.sub("---\n", "")
     File.write(source_dir("_data/site_metadata.yml"), metadata)
@@ -31,7 +30,16 @@ describe(BridgetownMediaTransformation) do
   end
 
   it "outputs a srcset with default transformations" do
-    expect(contents).to match '<source srcset="/assets/img/sample_image-640.webp 640w, /assets/img/sample_image-1024.webp 1024w, /assets/img/sample_image-1280.webp 1280w, /assets/img/sample_image-1920.webp 1920w, /assets/img/sample_image-3840.webp 2x" type="image/webp" />'
-    expect(contents).to match '<source srcset="/assets/img/sample_image-640.jpg 640w, /assets/img/sample_image-1024.jpg 1024w, /assets/img/sample_image-1280.jpg 1280w, /assets/img/sample_image-1920.jpg 1920w, /assets/img/sample_image-3840.jpg 2x" type="image/jpg" />'
+    contents = File.read(dest_dir("index.html"))
+
+    expect(contents).to match /\<source srcset\=\"\/assets\/img\/.*-sample_image-640.webp 640w, \/assets\/img\/.*-sample_image-1024.webp 1024w, \/assets\/img\/.+-sample_image-1280.webp 1280w, \/assets\/img\/.*-sample_image-1920.webp 1920w, \/assets\/img\/.*-sample_image-3840.webp 2x" type="image\/webp" \/>/
+    expect(contents).to match /\<source srcset\=\"\/assets\/img\/.*-sample_image-640.jpg 640w, \/assets\/img\/.*-sample_image-1024.jpg 1024w, \/assets\/img\/.+-sample_image-1280.jpg 1280w, \/assets\/img\/.*-sample_image-1920.jpg 1920w, \/assets\/img\/.*-sample_image-3840.jpg 2x" type="image\/jpg" \/>/
+  end
+
+  it "builds a lazyloading ready srcset" do
+    contents = File.read(dest_dir("lazy.html"))
+
+    expect(contents).to match /\<source data-srcset\=\"\/assets\/img\/.*-sample_image-640.webp 640w, \/assets\/img\/.*-sample_image-1024.webp 1024w, \/assets\/img\/.+-sample_image-1280.webp 1280w, \/assets\/img\/.*-sample_image-1920.webp 1920w, \/assets\/img\/.*-sample_image-3840.webp 2x" type="image\/webp" \/>/
+    expect(contents).to match /\<source data-srcset\=\"\/assets\/img\/.*-sample_image-640.jpg 640w, \/assets\/img\/.*-sample_image-1024.jpg 1024w, \/assets\/img\/.+-sample_image-1280.jpg 1280w, \/assets\/img\/.*-sample_image-1920.jpg 1920w, \/assets\/img\/.*-sample_image-3840.jpg 2x" type="image\/jpg" \/>/
   end
 end

--- a/spec/component_spec.rb
+++ b/spec/component_spec.rb
@@ -31,7 +31,7 @@ describe(BridgetownMediaTransformation) do
   end
 
   it "outputs a srcset with default transformations" do
-    expect(contents).to match '<source srcset="/assets/img/sample_image-640.webp 640w, /assets/img/sample_image-1024.webp 1024w, /assets/img/sample_image-1280.webp 1280w, /assets/img/sample_image-1920.webp 1920w, /assets/img/sample_image-3840.webp 2x" type="image/webp" />'
-    expect(contents).to match '<source srcset="/assets/img/sample_image-640.jpg 640w, /assets/img/sample_image-1024.jpg 1024w, /assets/img/sample_image-1280.jpg 1280w, /assets/img/sample_image-1920.jpg 1920w, /assets/img/sample_image-3840.jpg 2x" type="image/jpg" />'
+    expect(contents).to match /\<source srcset\=\"\/assets\/img\/.*-sample_image-640.webp 640w, \/assets\/img\/.*-sample_image-1024.webp 1024w, \/assets\/img\/.+-sample_image-1280.webp 1280w, \/assets\/img\/.*-sample_image-1920.webp 1920w, \/assets\/img\/.*-sample_image-3840.webp 2x" type="image\/webp" \/>/
+    expect(contents).to match /\<source srcset\=\"\/assets\/img\/.*-sample_image-640.jpg 640w, \/assets\/img\/.*-sample_image-1024.jpg 1024w, \/assets\/img\/.+-sample_image-1280.jpg 1280w, \/assets\/img\/.*-sample_image-1920.jpg 1920w, \/assets\/img\/.*-sample_image-3840.jpg 2x" type="image\/jpg" \/>/
   end
 end

--- a/spec/fixtures/src/lazy.html
+++ b/spec/fixtures/src/lazy.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+{% resp_picture /assets/img/sample_image.jpg, "{'lazy': true}" %}
+class="lazy"
+{% endresp_picture %}


### PR DESCRIPTION
I found myself a bit confused as to how the `kargs` were supposed to be passed to the `liquid_tag` and after finally figuring it out I thought to add a small test for it, both for the sake of testing the code, but also as a means of documenting the API.

This PR adds a test for the `lazy` keyword argument and updates the test suite to use regex for checking the resulting html.